### PR TITLE
Use port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We can take the defaults which select the lowest values for CPU, size, etc. This
 We can use `flyctl` to attach our app to the database which also sets our needed `DATABASE_URL` ENV value.
 
 ```cmd
-fly postgres attach --postgres-app hello-elixir-db
+fly postgres attach hello-elixir-db
 ```
 ```output
 Postgres cluster hello-elixir-db is now attached to icy-leaf-7381

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -38,7 +38,7 @@ if config_env() == :prod do
       raise "FLY_APP_NAME not available"
 
   config :hello_elixir, HelloElixirWeb.Endpoint,
-    url: [host: "#{app_name}.fly.dev", port: 80],
+    url: [host: "#{app_name}.fly.dev", port: 443],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
# Summary

Those using Fly will probably only use `https`. With that in mind, port 443 is a better and works with Elixir/Phoenix better too. 

Since this file is referenced a lot by others who are booting up new Elixir apps on fly, I thought it was worth updating. 

# Why 443?

I ran into this when using Phoenix's Endpoint.url() function in another app. The returned url had the port 80 in it. After looking into it, I realized that I should be using 443 instead. 

Refer to commit: https://github.com/fly-apps/hello_elixir/pull/8/commits/87d1798f32dc667b337a923a93a7f1b6d934da3d
